### PR TITLE
FEAT: Expose prepaidUnits detail and availableUnits on License object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.evolveum.polygon</groupId>
     <artifactId>connector-msgraph</artifactId>
-    <version>1.2.1.0-SNAPSHOT</version>
+    <version>1.2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>connector-microsoft-graph-api</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.evolveum.polygon</groupId>
     <artifactId>connector-msgraph</artifactId>
-    <version>1.2.2.0-SNAPSHOT</version>
+    <version>1.2.2.0</version>
     <packaging>jar</packaging>
 
     <name>connector-microsoft-graph-api</name>

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -28,7 +28,12 @@ public class LicenseProcessing extends ObjectProcessing {
     public static final String ATTR_ENABLED = "enabled";
     public static final String ATTR_SUSPENDED = "suspended";
     public static final String ATTR_WARNING = "warning";
+    public static final String ATTR_LOCKEDOUT = "lockedOut";
     public static final String ATTR_PREPAIDUNITS__ENABLED = ATTR_PREPAIDUNITS + "." + ATTR_ENABLED;
+    public static final String ATTR_PREPAIDUNITS__SUSPENDED = ATTR_PREPAIDUNITS + "." + ATTR_SUSPENDED;
+    public static final String ATTR_PREPAIDUNITS__WARNING = ATTR_PREPAIDUNITS + "." + ATTR_WARNING;
+    public static final String ATTR_PREPAIDUNITS__LOCKEDOUT = ATTR_PREPAIDUNITS + "." + ATTR_LOCKEDOUT;
+    public static final String ATTR_AVAILABLEUNITS = "availableUnits";
     // service plans
     public static final String ATTR_SERVICEPLANS = "servicePlans";
     public static final String ATTR_SERVICEPLANID = "servicePlanId";
@@ -100,7 +105,26 @@ public class LicenseProcessing extends ObjectProcessing {
                 .setCreateable(false)
                 .setUpdateable(false)
                 .setType(Integer.class)
-                .setMultiValued(true)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_PREPAIDUNITS__SUSPENDED)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setType(Integer.class)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_PREPAIDUNITS__WARNING)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setType(Integer.class)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_PREPAIDUNITS__LOCKEDOUT)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setType(Integer.class)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_AVAILABLEUNITS)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setType(Integer.class)
                 .build());
         attributes.add(new AttributeInfoBuilder(ATTR_SERVICEPLANS__SERVICEPLANID)
                 .setCreateable(false)
@@ -173,6 +197,17 @@ public class LicenseProcessing extends ObjectProcessing {
         getIfExists(json, ATTR_SKUID, String.class, builder);
         getIfExists(json, ATTR_SKUPAATNUMBER, String.class, builder);
         getFromItemIfExists(json, ATTR_PREPAIDUNITS, ATTR_ENABLED, Integer.class, builder);
+        getFromItemIfExists(json, ATTR_PREPAIDUNITS, ATTR_SUSPENDED, Integer.class, builder);
+        getFromItemIfExists(json, ATTR_PREPAIDUNITS, ATTR_WARNING, Integer.class, builder);
+        getFromItemIfExists(json, ATTR_PREPAIDUNITS, ATTR_LOCKEDOUT, Integer.class, builder);
+
+        int enabled = json.has(ATTR_PREPAIDUNITS) && json.getJSONObject(ATTR_PREPAIDUNITS).has(ATTR_ENABLED)
+                ? json.getJSONObject(ATTR_PREPAIDUNITS).getInt(ATTR_ENABLED) : 0;
+        int warning = json.has(ATTR_PREPAIDUNITS) && json.getJSONObject(ATTR_PREPAIDUNITS).has(ATTR_WARNING)
+                ? json.getJSONObject(ATTR_PREPAIDUNITS).getInt(ATTR_WARNING) : 0;
+        int consumed = json.has(ATTR_CONSUMEDUNITS) ? json.getInt(ATTR_CONSUMEDUNITS) : 0;
+        builder.addAttribute(ATTR_AVAILABLEUNITS, (enabled + warning) - consumed);
+
         getFromArrayIfExists(json, ATTR_SERVICEPLANS, ATTR_SERVICEPLANID, String.class, builder);
 
         return handler.handle(builder.build());

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/LicenseTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/LicenseTest.java
@@ -164,6 +164,18 @@ public class LicenseTest extends BasicConfigurationForTests {
                 Attribute attrSkuId = co.getAttributeByName(LicenseProcessing.ATTR_SKUID);
                 String skuId = attrSkuId == null ? null : AttributeUtil.getAsStringValue(attrSkuId);
                 LOG.info("License: skuId {0}, skuPartNumber {1}", skuId, co.getName().getNameValue());
+
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__ENABLED),
+                        "prepaidUnits.enabled should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__SUSPENDED),
+                        "prepaidUnits.suspended should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__WARNING),
+                        "prepaidUnits.warning should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__LOCKEDOUT),
+                        "prepaidUnits.lockedOut should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_AVAILABLEUNITS),
+                        "availableUnits should be present");
+
                 if (skuId != null)
                     remains.remove(skuId);
             }
@@ -195,6 +207,21 @@ public class LicenseTest extends BasicConfigurationForTests {
                 String skuId = attrSkuId == null ? null : AttributeUtil.getAsStringValue(attrSkuId);
                 String id = attrId == null ? null : AttributeUtil.getAsStringValue(attrId);
                 LOG.info("License: skuId: {0}, skuPartNumber: {1}, id: {2}", skuId, co.getName().getNameValue(), id);
+
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__ENABLED),
+                        "prepaidUnits.enabled should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__SUSPENDED),
+                        "prepaidUnits.suspended should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__WARNING),
+                        "prepaidUnits.warning should be present");
+                assertNotNull(co.getAttributeByName(LicenseProcessing.ATTR_PREPAIDUNITS__LOCKEDOUT),
+                        "prepaidUnits.lockedOut should be present");
+
+                Attribute attrAvailable = co.getAttributeByName(LicenseProcessing.ATTR_AVAILABLEUNITS);
+                assertNotNull(attrAvailable, "availableUnits should be present");
+                Integer availableUnits = AttributeUtil.getIntegerValue(attrAvailable);
+                assertNotNull(availableUnits, "availableUnits should have a value");
+                LOG.info("License: availableUnits: {0}", availableUnits);
 
                 if (idFromHandler == null) {
 


### PR DESCRIPTION
  Adds prepaidUnits.suspended, prepaidUnits.warning, prepaidUnits.lockedOut
  and computed availableUnits ((enabled + warning) - consumed) attributes
  on the License object class. Also fixes prepaidUnits.enabled, which was
  incorrectly declared as multivalued. Bumps version to 1.2.2.0-SNAPSHOT.